### PR TITLE
Postgres 9.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,15 @@ Building:
     ` python setup.py bdist --formats=zip` and then deploy the zip file, run it
     with `python zipfile.zip`
 
+
+Hacking
+    Running ancient postgres in production and want to test it?
+    $ podman run --rm=true  -p 5432 -ti centos:6
+    $ rpm -ivh https://download.postgresql.org/pub/repos/yum/9.1/redhat/rhel-6-x86_64/pgdg-centos91-9.1-6.noarch.rpm
+    $ yum install postgresql91-server  postgresql91
+    $ su - postgres
+    $ /usr/pgsql-9.1/bin/initdb /var/lib/pgsql/9.1/data/
+    $ edit postgresql.conf, add listen = "*"
+    $ edit pg_hba.conf, add connect / trust  
+
+    $ /usr/pgsql-9.1/bin/postgres -D /var/lib/pgsql/9.1/data

--- a/pgzabbix/__init__.py
+++ b/pgzabbix/__init__.py
@@ -118,11 +118,11 @@ def discover_db(cur):
 
 
 def list_databases_we_can_connect_to_and_fuck_off(cur):
-        query = ("select datname, pg_database_size(datname) from pg_database "
-                 " where datistemplate = 'f' and "
-                 " has_database_privilege(datname, 'CONNECT')")
-        cur.execute(query)
-        return [x[0] for x in cur]
+    query = ("select datname, pg_database_size(datname) from pg_database "
+             " where datistemplate = 'f' and "
+             " has_database_privilege(datname, 'CONNECT')")
+    cur.execute(query)
+    return [x[0] for x in cur]
 
 
 def foreach_db(config, perdb_function):

--- a/pgzabbix/cmd.py
+++ b/pgzabbix/cmd.py
@@ -39,8 +39,8 @@ def commandline():
                         default='/etc/pgzabbix.ini'
                         )
     group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument('--read',     action='store_true', default=False)
-    group.add_argument('--tables',   action='store_true', default=False)
+    group.add_argument('--read', action='store_true', default=False)
+    group.add_argument('--tables', action='store_true', default=False)
     group.add_argument('--discover', action='store_true', default=False)
     group.add_argument('--discover_tables', action='store_true', default=False)
     group.add_argument('--discover_db', action='store_true', default=False)
@@ -77,6 +77,7 @@ def main():
 
     cur.close()
     conn.close()
+
 
 if __name__ == "__main__":
     main()

--- a/pgzabbix/database.py
+++ b/pgzabbix/database.py
@@ -76,6 +76,10 @@ def db_tx_commited(cur):
 
 
 def db_deadlocks(cur):
+    vers = cur.connection.server_version
+    if vers <= 90125:
+        # Old postgresql version
+        return
     cur.execute("select datname, deadlocks from pg_stat_database"
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
@@ -93,6 +97,10 @@ def db_tx_rolledback(cur):
 
 
 def db_temp_bytes(cur):
+    vers = cur.connection.server_version
+    if vers <= 90125:
+        # Old postgresql version
+        return
     cur.execute("select datname, temp_bytes from pg_stat_database"
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")

--- a/pgzabbix/replication.py
+++ b/pgzabbix/replication.py
@@ -10,7 +10,10 @@ def view_select(cur):
 
 def write_diff(cur):
     vers = cur.connection.server_version
-    if vers <  100000:
+    if vers <= 90124:
+        # Postgres 9.1 Doesn't support diffing the xlog locations
+        return
+    elif vers < 100000:
         query = ("SELECT host(client_addr), "
                  " pg_xlog_location_diff(sent_location, write_location) "
                  " from {table}")
@@ -26,7 +29,10 @@ def write_diff(cur):
 
 def replay_diff(cur):
     vers = cur.connection.server_version
-    if vers <  100000:
+    if vers <= 90124:
+        # Postgres 9.1 Doesn't support diffing the xlog locations
+        return
+    elif vers < 100000:
         query = ("SELECT host(client_addr), "
                  " pg_xlog_location_diff(sent_location, replay_location) "
                  " from {table}")


### PR DESCRIPTION
This sadly disables tracking of some useful features, like xlog delay and so on, but those aren't supported on pg 9.1 natively, so that's what there is.

Other than that, some more ugly work-arounds for older postgres versions.

Closes: #2