### PR TITLE
Rework all .format uses to have indexes on them

### DIFF
--- a/pgzabbix/database.py
+++ b/pgzabbix/database.py
@@ -15,7 +15,7 @@ def psql_db_size(cur):
              " has_database_privilege(datname, 'CONNECT')")
     cur.execute(query)
     for row in cur.fetchall():
-        yield ("psql.db_size[{}]".format(row[0]), row[1])
+        yield ("psql.db_size[{0}]".format(row[0]), row[1])
 
 
 def psql_db_garbage_ratio(cur):
@@ -23,7 +23,7 @@ def psql_db_garbage_ratio(cur):
 #    cur.execute("select datname, pg_database_size(datname) from pg_database "
 #                " where datistemplate = 'f'")
 #    for row in cur.fetchall():
-#        yield ("psql.db_size[{}]".format(row[0]), row[1])
+#        yield ("psql.db_size[{0}]".format(row[0]), row[1])
 
 
 def confl_tablespace(cur):
@@ -31,7 +31,7 @@ def confl_tablespace(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.confl_tablespace[{}]'.format(row[0]), row[1])
+        yield ('psql.confl_tablespace[{0}]'.format(row[0]), row[1])
 
 
 def confl_lock(cur):
@@ -39,7 +39,7 @@ def confl_lock(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.confl_lock[{}]'.format(row[0]), row[1])
+        yield ('psql.confl_lock[{0}]'.format(row[0]), row[1])
 
 
 def confl_snapshot(cur):
@@ -47,7 +47,7 @@ def confl_snapshot(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.confl_snapshot[{}]'.format(row[0]), row[1])
+        yield ('psql.confl_snapshot[{0}]'.format(row[0]), row[1])
 
 
 def confl_bufferpin(cur):
@@ -55,7 +55,7 @@ def confl_bufferpin(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.confl_bufferpin[{}]'.format(row[0]), row[1])
+        yield ('psql.confl_bufferpin[{0}]'.format(row[0]), row[1])
 
 
 def confl_deadlock(cur):
@@ -64,7 +64,7 @@ def confl_deadlock(cur):
                 " where pg_database.datistemplate=False;")
 
     for row in cur.fetchall():
-        yield ('psql.confl_deadlock[{}]'.format(row[0]), row[1])
+        yield ('psql.confl_deadlock[{0}]'.format(row[0]), row[1])
 
 
 def db_tx_commited(cur):
@@ -72,7 +72,7 @@ def db_tx_commited(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_tx_commited[{}]'.format(row[0]), row[1])
+        yield ('psql.db_tx_commited[{0}]'.format(row[0]), row[1])
 
 
 def db_deadlocks(cur):
@@ -85,7 +85,7 @@ def db_deadlocks(cur):
                 " where pg_database.datistemplate=False;")
 
     for row in cur.fetchall():
-        yield ('psql.db_deadlocks[{}]'.format(row[0]), row[1])
+        yield ('psql.db_deadlocks[{0}]'.format(row[0]), row[1])
 
 
 def db_tx_rolledback(cur):
@@ -93,7 +93,7 @@ def db_tx_rolledback(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_tx_rolledback[{}]'.format(row[0]), row[1])
+        yield ('psql.db_tx_rolledback[{0}]'.format(row[0]), row[1])
 
 
 def db_temp_bytes(cur):
@@ -105,7 +105,7 @@ def db_temp_bytes(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_temp_bytes[{}]'.format(row[0]), row[1])
+        yield ('psql.db_temp_bytes[{0}]'.format(row[0]), row[1])
 
 
 def db_deleted(cur):
@@ -113,7 +113,7 @@ def db_deleted(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_deleted[{}]'.format(row[0]), row[1])
+        yield ('psql.db_deleted[{0}]'.format(row[0]), row[1])
 
 
 def db_fetched(cur):
@@ -121,7 +121,7 @@ def db_fetched(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_fetched[{}]'.format(row[0]), row[1])
+        yield ('psql.db_fetched[{0}]'.format(row[0]), row[1])
 
 
 def db_inserted(cur):
@@ -129,7 +129,7 @@ def db_inserted(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_inserted[{}]'.format(row[0]), row[1])
+        yield ('psql.db_inserted[{0}]'.format(row[0]), row[1])
 
 
 def db_returned(cur):
@@ -137,7 +137,7 @@ def db_returned(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_returned[{}]'.format(row[0]), row[1])
+        yield ('psql.db_returned[{0}]'.format(row[0]), row[1])
 
 
 def db_updated(cur):
@@ -145,7 +145,7 @@ def db_updated(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_updated[{}]'.format(row[0]), row[1])
+        yield ('psql.db_updated[{0}]'.format(row[0]), row[1])
 
 
 def db_connections(cur):
@@ -153,7 +153,7 @@ def db_connections(cur):
                 " inner join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.db_connections[{}]'.format(row[0]), row[1])
+        yield ('psql.db_connections[{0}]'.format(row[0]), row[1])
 
 
 def db_cachehit_ratio(cur):
@@ -162,4 +162,4 @@ def db_cachehit_ratio(cur):
                 "  inner  join pg_database using (datname)"
                 " where pg_database.datistemplate=False;")
     for row in cur.fetchall():
-        yield ('psql.cachehit_ratio[{}]'.format(row[0]), row[1])
+        yield ('psql.cachehit_ratio[{0}]'.format(row[0]), row[1])

--- a/pgzabbix/generic.py
+++ b/pgzabbix/generic.py
@@ -85,11 +85,11 @@ def psql_slow_dml_queries(cur, limit=123):
     if vers <= 90125:
         query = (
             "select count(*) from pg_stat_activity where current_query not like '<IDLE>%'"
-            " and now() - query_start > '{} sec'::interval "
+            " and now() - query_start > '{0} sec'::interval "
             " and current_query ~* '^(insert|update|delete)'").format(limit)
     else:
         query = ("select count(*) from pg_stat_activity where state = 'active' "
-                 " and now() - query_start > '{} sec'::interval "
+                 " and now() - query_start > '{0} sec'::interval "
                  " and query ~* '^(insert|update|delete)'").format(limit)
     cur.execute(query)
     for row in cur.fetchall():
@@ -101,10 +101,10 @@ def psql_slow_queries(cur, limit=123):
     if vers <= 90125:
         query = (
             "select count(*) from pg_stat_activity where current_query not like '<IDLE>%'"
-            " and now() - query_start > '{} sec'::interval").format(limit)
+            " and now() - query_start > '{0} sec'::interval").format(limit)
     else:
         query = ("select count(*) from pg_stat_activity where state = 'active' "
-                 " and now() - query_start > '{} sec'::interval").format(limit)
+                 " and now() - query_start > '{0} sec'::interval").format(limit)
     cur.execute(query)
     for row in cur.fetchall():
         yield ("psql.slow_queries", row[0])
@@ -115,10 +115,10 @@ def psql_slow_select_queries(cur, limit=123):
     if vers <= 90125:
         query = (
             "select count(*) from pg_stat_activity where current_query ilike 'select%'"
-            " and now() - query_start > '{} sec'::interval").format(limit)
+            " and now() - query_start > '{0} sec'::interval").format(limit)
     else:
         query = ("select count(*) from pg_stat_activity where state = 'active' "
-                 " and now() - query_start > '{} sec'::interval "
+                 " and now() - query_start > '{0} sec'::interval "
                  " and query ilike 'select%'").format(limit)
     cur.execute(query)
     for row in cur.fetchall():

--- a/pgzabbix/replication.py
+++ b/pgzabbix/replication.py
@@ -24,7 +24,7 @@ def write_diff(cur):
 
     cur.execute(query.format(table=view_select(cur)))
     for row in cur.fetchall():
-        yield ('psql.write_diff[{}]'.format(row[0]), row[1])
+        yield ('psql.write_diff[{0}]'.format(row[0]), row[1])
 
 
 def replay_diff(cur):
@@ -43,7 +43,7 @@ def replay_diff(cur):
 
     cur.execute(query.format(table=view_select(cur)))
     for row in cur.fetchall():
-        yield ('psql.replay_diff[{}]'.format(row[0]), row[1])
+        yield ('psql.replay_diff[{0}]'.format(row[0]), row[1])
 
 
 def sync_priority(cur):
@@ -53,7 +53,7 @@ def sync_priority(cur):
 
     cur.execute(query.format(table=view_select(cur)))
     for row in cur.fetchall():
-        yield ('psql.sync_priority[{}]'.format(row[0]), row[1])
+        yield ('psql.sync_priority[{0}]'.format(row[0]), row[1])
 
 
 def sr_discovery(cur):

--- a/pgzabbix/table.py
+++ b/pgzabbix/table.py
@@ -1,7 +1,7 @@
 
 def psql_table_analyze_count(cur):
     query = "select current_database(), schemaname, relname, analyze_count from pg_stat_user_tables"
-    out = "psql.table_analyze_count[{},{},{}]"
+    out = "psql.table_analyze_count[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -9,7 +9,7 @@ def psql_table_analyze_count(cur):
 
 def psql_table_autoanalyze_count(cur):
     query = "select current_database(), schemaname, relname, autoanalyze_count from pg_stat_user_tables"
-    out = "psql.table_autoanalyze_count[{},{},{}]"
+    out = "psql.table_autoanalyze_count[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -17,7 +17,7 @@ def psql_table_autoanalyze_count(cur):
 
 def psql_table_autovacuum_count(cur):
     query = "select current_database(), schemaname, relname, autovacuum_count from pg_stat_user_tables"
-    out = "psql.table_autovacuum_count[{},{},{}]"
+    out = "psql.table_autovacuum_count[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -25,7 +25,7 @@ def psql_table_autovacuum_count(cur):
 
 def psql_table_n_dead_tup(cur):
     query = "select current_database(), schemaname, relname, n_dead_tup from pg_stat_user_tables"
-    out = "psql.table_n_dead_tup[{},{},{}]"
+    out = "psql.table_n_dead_tup[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -33,7 +33,7 @@ def psql_table_n_dead_tup(cur):
 
 def psql_table_n_tup_del(cur):
     query = "select current_database(), schemaname, relname, n_tup_del from pg_stat_user_tables"
-    out = "psql.table_n_tup_del[{},{},{}]"
+    out = "psql.table_n_tup_del[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -41,7 +41,7 @@ def psql_table_n_tup_del(cur):
 
 def psql_table_n_tup_hot_upd(cur):
     query = "select current_database(), schemaname, relname, n_tup_hot_upd from pg_stat_user_tables"
-    out = "psql.table_n_tup_hot_upd[{},{},{}]"
+    out = "psql.table_n_tup_hot_upd[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -49,7 +49,7 @@ def psql_table_n_tup_hot_upd(cur):
 
 def psql_table_idx_scan(cur):
     query = "select current_database(), schemaname, relname, coalesce(idx_scan, 0) from pg_stat_user_tables"
-    out = "psql.table_idx_scan[{},{},{}]"
+    out = "psql.table_idx_scan[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -57,7 +57,7 @@ def psql_table_idx_scan(cur):
 
 def psql_table_seq_tup_read(cur):
     query = "select current_database(), schemaname, relname, coalesce(seq_tup_read, 0) from pg_stat_user_tables"
-    out = "psql.table_seq_tup_read[{},{},{}]"
+    out = "psql.table_seq_tup_read[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -65,7 +65,7 @@ def psql_table_seq_tup_read(cur):
 
 def psql_table_idx_tup_fetch(cur):
     query = "select current_database(), schemaname, relname, coalesce(idx_tup_fetch,0) from pg_stat_user_tables"
-    out = "psql.table_idx_tup_fetch[{},{},{}]"
+    out = "psql.table_idx_tup_fetch[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -73,7 +73,7 @@ def psql_table_idx_tup_fetch(cur):
 
 def psql_table_idx_tup_ins(cur):
     query = "select current_database(), schemaname, relname, n_tup_ins from pg_stat_user_tables"
-    out = "psql.table_n_tup_ins[{},{},{}]"
+    out = "psql.table_n_tup_ins[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -81,7 +81,7 @@ def psql_table_idx_tup_ins(cur):
 
 def psql_table_n_live_tup(cur):
     query = "select current_database(), schemaname, relname, n_live_tup from pg_stat_user_tables"
-    out = "psql.table_n_live_tup[{},{},{}]"
+    out = "psql.table_n_live_tup[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -89,7 +89,7 @@ def psql_table_n_live_tup(cur):
 
 def psql_table_seq_scan(cur):
     query = "select current_database(), schemaname, relname, seq_scan from pg_stat_user_tables"
-    out = "psql.table_seq_scan[{},{},{}]"
+    out = "psql.table_seq_scan[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -97,7 +97,7 @@ def psql_table_seq_scan(cur):
 
 def psql_table_n_tup_upd(cur):
     query = "select current_database(), schemaname, relname, n_tup_upd from pg_stat_user_tables"
-    out = "psql.table_n_tup_upd[{},{},{}]"
+    out = "psql.table_n_tup_upd[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -105,7 +105,7 @@ def psql_table_n_tup_upd(cur):
 
 def psql_table_vacuum_count(cur):
     query = "select current_database(), schemaname, relname, vacuum_count from pg_stat_user_tables"
-    out = "psql.table_vacuum_count[{},{},{}]"
+    out = "psql.table_vacuum_count[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -113,7 +113,7 @@ def psql_table_vacuum_count(cur):
 
 def psql_table_total_size(cur):
     query = "select current_database(), schemaname, relname, pg_total_relation_size(relid) from pg_stat_user_tables"
-    out = "psql.table_total_size[{},{},{}]"
+    out = "psql.table_total_size[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]
@@ -123,7 +123,7 @@ def psql_table_heap_cachehit_ratio(cur):
     query = ("select current_database(), schemaname, relname, "
              " round(heap_blks_hit * 100.0 / greatest(heap_blks_hit + heap_blks_read, 1), 2) "
              " from pg_statio_user_tables")
-    out = "psql.table_heap_cachehit_ratio[{},{},{}]"
+    out = "psql.table_heap_cachehit_ratio[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         if row[3] is None:
@@ -135,7 +135,7 @@ def psql_table_idx_cachehit_ratio(cur):
     query = ("select current_database(), schemaname, relname, "
              " round(idx_blks_hit * 100.0 / greatest(idx_blks_hit + idx_blks_read, 1), 2) "
              " from pg_statio_user_tables;")
-    out = "psql.table_idx_cachehit_ratio[{},{},{}]"
+    out = "psql.table_idx_cachehit_ratio[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         if row[3] is None:
@@ -147,7 +147,7 @@ def psql_table_garbage_ratio(cur):
     query = ("select current_database(), schemaname, relname, "
              " round(n_dead_tup / greatest(n_live_tup + n_dead_tup , 1), 2) "
              " from  pg_stat_user_tables;")
-    out = "psql.table_garbage_ratio[{},{},{}]"
+    out = "psql.table_garbage_ratio[{0},{1},{2}]"
     cur.execute(query)
     for row in cur.fetchall():
         yield out.format(*row[:3]), row[3]


### PR DESCRIPTION
This might be all that's needed to support python 2.6 in old legacy systems.